### PR TITLE
Refactor and Fix: Replace div with span in AlertModalTitle and ModalTitle to Avoid HTML Nesting Warning

### DIFF
--- a/src/components/AlertModal/AlertModal.tsx
+++ b/src/components/AlertModal/AlertModal.tsx
@@ -149,7 +149,7 @@ export const AlertModalTitle = forwardRef<HTMLDivElement, AlertModalTitleProps>(
             )}
           >
             {status && (
-              <div className="mr-2 invisible">{getStatusIcon(status)}</div>
+              <span className="mr-2 invisible">{getStatusIcon(status)}</span>
             )}
             {description}
           </AlertDialog.Description>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -59,7 +59,12 @@ const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
   ) => {
     return (
       <Dialog.Portal>
-        <Dialog.Overlay className={cn(" bg-black bg-opacity-20 data-[state=open]:animate-overlayShow fixed inset-0", overlayClassName)} />
+        <Dialog.Overlay
+          className={cn(
+            " bg-black bg-opacity-20 data-[state=open]:animate-overlayShow fixed inset-0",
+            overlayClassName
+          )}
+        />
         <Dialog.Content
           {...props}
           ref={forwardedRef}
@@ -113,7 +118,7 @@ const ModalTitle = React.forwardRef<HTMLDivElement, ModalTitleProps>(
             )}
           >
             {status && (
-              <div className="mr-2 invisible">{getStatusIcon(status)}</div>
+              <span className="mr-2 invisible">{getStatusIcon(status)}</span>
             )}
             {description}
           </Dialog.Description>


### PR DESCRIPTION
- Changed a div element to a span within the AlertModalTitle component to resolve the warning: "In HTML, <div> cannot be a descendant of <p>". This change prevents potential hydration errors.
- 
- Refactored ModalTitle component by replacing a div element with a span to avoid similar HTML nesting issues and ensure consistency